### PR TITLE
Close out UL tags in Examples

### DIFF
--- a/site/docs/01-the-basics/38-finding-nodes.html.md
+++ b/site/docs/01-the-basics/38-finding-nodes.html.md
@@ -42,7 +42,7 @@ Let's say you're building a blog, and you're saving your blog posts in a `/posts
   <% find("/posts").pages.each do |post| %>
     <li><%= link_to post.title, post %></li> %>
   <% end %>
-</li>
+</ul>
 ~~~
 
 Consider that `pages` (and its friends) returns a simple Ruby array which you can further filter. For example, you may want to remove any posts that are marked as a draft through their front matter:
@@ -52,5 +52,5 @@ Consider that `pages` (and its friends) returns a simple Ruby array which you ca
   <% find("/posts").pages.reject { |p| p.data.draft }.each do |post| %>
     <li><%= link_to post.title, post %></li> %>
   <% end %>
-</li>
+</ul>
 ~~~


### PR DESCRIPTION
Their were two close-list-item tags that should have been close-unordered-list tags, I think.